### PR TITLE
Sawtooth (CA65 ver) now has overdrive behavior.

### DIFF
--- a/ggsound_ca65/ggsound.asm
+++ b/ggsound_ca65/ggsound.asm
@@ -1388,7 +1388,7 @@ skip_duty_loop:
 
     ;Or the duty value into the register.
     lda (sound_local_word_0),y
-    lsr
+    asl
     and #%00100000
     sta sound_local_byte_0
     lda stream_channel_register_1,x


### PR DESCRIPTION
Replaced the ```LSR``` with an ```ASL```. Only for the CA65 version though. Apologies for being lazy!